### PR TITLE
[RTC-348] Add API versioning section

### DIFF
--- a/docs/api_reference/versioning.md
+++ b/docs/api_reference/versioning.md
@@ -1,0 +1,57 @@
+# Api Versioning
+
+In order to ensure Jellyfish backward compatibility with older SDKs,
+we introduce versioning to OpenAPI REST specification
+and protbuf WebSocket specification.
+
+We want to introduce new changes to the Jellyfish and those changes have to be
+reflected in the SDKs.
+The changes are in the OpenAPI and protobuf.
+There are a couple ideas on how to solve this problem:
+
+## Current approach
+In the current workflow we version Jellyfish together with OpenAPI and protobuf.
+The same version number is applied to SDKs and we enforce using the same Jellyfish and SDK versions.
+
+Pros:
+* easy to introduce changes (no backward compatibility required)
+* easy to test - only test with the current version
+
+Cons: 
+* no backward compatibility
+
+
+## Proposed Approach
+Introduce breaking changes gradually.
+
+Example:
+Let's say that we introduce backward-compatible changes between Jellyfish
+`0.2.0` versions and `0.4.0` versions. In the process we marked
+some fields as `deprecated` and remove them in Jellyfish `0.5.0`, while
+preserving compatibility with JF `0.3.0` and `0.4.0`.
+Similarily, in the version `0.6.0` we will likely break compatibility with `0.3.0` but remain compatible with `0.4.0` and `0.5.0`.
+
+
+In this scenario we need to decide how to version the API.
+The best way would be to keep it the same as Jellyfish, since most of the times any change in Jellyfish causes changes either in REST api or WebSocket api.
+
+The downside is that a change in REST api triggers version change
+in WebSocket api and vice versa. This is a disadvantage if someone uses 
+solely either REST api or WebSocket api - they would have to update version 
+even if there was no change in the API they were using.
+
+Pros:
+* backward-compatibility is provided to some point, e.g. up to two or three Jellyfish versions
+
+Cons:
+* more complicated testing - we have to test thoroughly each version combination we pledge viable
+* we need to provide the compatibility information to the users, semantic versioning isn't sufficient
+
+## Variations
+
+Instead of introducing breaking changes with every release, we could
+decide to introduce breaking changes in bulk, e.g.
+
+JF `0.2.0` -> `0.6.0` - all backward compatible
+in JF `0.7.0` - introduce all changes previously marked as deprecated,
+making `0.7.0` incompatible even with `0.6.0`

--- a/docs/api_reference/versioning.md
+++ b/docs/api_reference/versioning.md
@@ -24,16 +24,13 @@ newer Jellyfish until they are upgraded as well.
 ## Testing
 
 In order to assure quality, all the versions declared compatible
-will be tested against each other.
+should be tested for compatibility, i.e. if a given test suite
+passes for a given release, it should also pass for the following
+compatible releases.
 
 At minimum, we should check that there are no breaking changes
 between API versions, or that the breaking changes are only
 related to resources previously marked deprecated.
-
-Tool such as [oasdiff](https://github.com/Tufin/oasdiff)
-will be of great help here.
-[Here](https://github.com/Tufin/oasdiff/blob/main/API-DEPRECATION.md)
-the oasdiff describes removal of deprecated resources.
 
 Simmilar tools are available for protobuf.
 

--- a/docs/api_reference/versioning.md
+++ b/docs/api_reference/versioning.md
@@ -1,20 +1,19 @@
 # Versioning Strategy for APIs
 
 ## Current approach
-In the current workflow we version Jellyfish together with OpenAPI and protobuf.
+In the current workflow, we version Jellyfish together with OpenAPI and protobuf.
 The same version number is applied to SDKs and we enforce using the same Jellyfish and SDK versions.
 
-This is great from developer perspective, but causes issues from
+This is great from a developer perspective, but causes issues from
 the user perspective.
-The main problem is the neccessity to update both Jellyfish and SDK
+The main problem is the necessity to update both Jellyfish and SDK
 at the same moment.
 
-
-Pros:
+### Pros
 * easy to introduce changes (no backward compatibility required)
 * easy to test - only test with the current version
 
-Cons: 
+### Cons
 * no backward compatibility
 
 
@@ -22,43 +21,48 @@ Cons:
 Introducing breaking changes gradually.
 
 This scenario proposes introducing breaking changes gradually,
-first by making the old features deprecated and removing them
+first by making the old features deprecated, and removing them
 later, giving users some time to adapt to the changes.
 
-This allows for progressive introduction of new version of Jellyfish,
+This allows for the progressive introduction of new versions of Jellyfish,
 e.g. first by updating the Jellyfish Server and then the SDK.
-This also allows for working with two system versions at the same time,
+This also allows for working with two system versions at the same time
+(SDK connecting to different Jellyfish versions),
 until everything is upgraded.
 
-Example:
+### Example
 Let's say that we introduce backward-compatible changes between Jellyfish
-`0.2.0` versions and `0.4.0` versions. In the process we marked
-some fields as deprecated and remove them in Jellyfish `0.5.0`, while
-preserving compatibility with JF `0.3.0` and `0.4.0`.
-Similarily, in the version `0.6.0` we will likely break compatibility with `0.3.0` but remain compatible with `0.4.0` and `0.5.0`.
+`0.2.0` versions and `0.4.0` versions. In the process, we marked
+some fields as deprecated and then remove them in Jellyfish `0.5.0`,
+while preserving compatibility with JF `0.3.0` and `0.4.0`.
+Similarly, in the version `0.6.0` we will likely break compatibility
+with `0.3.0` but remain compatible with `0.4.0` and `0.5.0`.
 
+In this scenario, we need to decide how to version the API.
+The best way would be to keep it the same as Jellyfish,
+since most of the time any change in REST or WebSocket causes
+changes in Jellyfish.
 
-In this scenario we need to decide how to version the API.
-The best way would be to keep it the same as Jellyfish, since most of the times any change in REST or WebSocket causes changes in Jellyfish.
+The downside is that a change in REST API triggers a version change
+in WebSocket API and vice versa. This is a disadvantage if someone uses 
+solely either REST API or WebSocket API - they would have to
+update the version even if there was no change in the API they were using.
 
-The downside is that a change in REST api triggers version change
-in WebSocket api and vice versa. This is a disadvantage if someone uses 
-solely either REST api or WebSocket api - they would have to update version 
-even if there was no change in the API they were using.
+We also have to test backward compatibility of the new changes we introduce.
 
-We also have to test backward-compatibility of the new changes we introduce.
-
-Pros:
+### Pros
 * backward-compatibility is provided to some point, e.g. up to two or three Jellyfish versions
 
-Cons:
-* more complicated testing - we have to test thoroughly each version combination we pledge viable
-* we need to provide the compatibility information to the users, semantic versioning isn't sufficient
+### Cons
+* more complicated testing - we have to test thoroughly each
+version combination we pledge viable
+* we need to provide the compatibility information to the users,
+semantic versioning isn't sufficient
 
 ## Variations
 
 Instead of introducing breaking changes with every release, we could
-decide to introduce breaking changes in bulk, e.g.
+decide to implement them in bulk, e.g.
 
 JF `0.2.0` -> `0.6.0` - all backward compatible
 in JF `0.7.0` - introduce all changes previously marked as deprecated,

--- a/docs/api_reference/versioning.md
+++ b/docs/api_reference/versioning.md
@@ -1,17 +1,14 @@
-# Api Versioning
-
-In order to ensure Jellyfish backward compatibility with older SDKs,
-we introduce versioning to OpenAPI REST specification
-and protbuf WebSocket specification.
-
-We want to introduce new changes to the Jellyfish and those changes have to be
-reflected in the SDKs.
-The changes are in the OpenAPI and protobuf.
-There are a couple ideas on how to solve this problem:
+# Versioning Strategy for APIs
 
 ## Current approach
 In the current workflow we version Jellyfish together with OpenAPI and protobuf.
 The same version number is applied to SDKs and we enforce using the same Jellyfish and SDK versions.
+
+This is great from developer perspective, but causes issues from
+the user perspective.
+The main problem is the neccessity to update both Jellyfish and SDK
+at the same moment.
+
 
 Pros:
 * easy to introduce changes (no backward compatibility required)
@@ -22,23 +19,34 @@ Cons:
 
 
 ## Proposed Approach
-Introduce breaking changes gradually.
+Introducing breaking changes gradually.
+
+This scenario proposes introducing breaking changes gradually,
+first by making the old features deprecated and removing them
+later, giving users some time to adapt to the changes.
+
+This allows for progressive introduction of new version of Jellyfish,
+e.g. first by updating the Jellyfish Server and then the SDK.
+This also allows for working with two system versions at the same time,
+until everything is upgraded.
 
 Example:
 Let's say that we introduce backward-compatible changes between Jellyfish
 `0.2.0` versions and `0.4.0` versions. In the process we marked
-some fields as `deprecated` and remove them in Jellyfish `0.5.0`, while
+some fields as deprecated and remove them in Jellyfish `0.5.0`, while
 preserving compatibility with JF `0.3.0` and `0.4.0`.
 Similarily, in the version `0.6.0` we will likely break compatibility with `0.3.0` but remain compatible with `0.4.0` and `0.5.0`.
 
 
 In this scenario we need to decide how to version the API.
-The best way would be to keep it the same as Jellyfish, since most of the times any change in Jellyfish causes changes either in REST api or WebSocket api.
+The best way would be to keep it the same as Jellyfish, since most of the times any change in REST or WebSocket causes changes in Jellyfish.
 
 The downside is that a change in REST api triggers version change
 in WebSocket api and vice versa. This is a disadvantage if someone uses 
 solely either REST api or WebSocket api - they would have to update version 
 even if there was no change in the API they were using.
+
+We also have to test backward-compatibility of the new changes we introduce.
 
 Pros:
 * backward-compatibility is provided to some point, e.g. up to two or three Jellyfish versions

--- a/docs/api_reference/versioning.md
+++ b/docs/api_reference/versioning.md
@@ -1,69 +1,40 @@
 # Versioning Strategy for APIs
 
-## Current approach
-In the current workflow, we version Jellyfish together with OpenAPI and protobuf.
-The same version number is applied to SDKs and we enforce using the same Jellyfish and SDK versions.
+## Motivation
 
-This is great from a developer perspective, but causes issues from
-the user perspective.
-The main problem is the necessity to update both Jellyfish and SDK
-at the same moment.
+The Jellyfish API consists of two transports: http REST API 
+and WebSocket using protobuf. The two APIs can be found in
+the [api-description repository](https://github.com/jellyfish-dev/protos).
 
-### Pros
-* easy to introduce changes (no backward compatibility required)
-* easy to test - only test with the current version
+In order to ensure ease of use we introduce versioning to the Jellyfish API.
+The versioning of the API provides reference points when comparing
+changes and allows to name compatible (and incompatible)
+versions of the API.
 
-### Cons
-* no backward compatibility
+## Workflow
 
+Whenever it is possible, we try to introduce backward-compatible changes
+in the API, allowing for smoother transition between Jellyfish versions.
 
-## Proposed Approach
-Introducing breaking changes gradually.
+When we decide to remove particular functionality, we first mark
+it as `deprecated` and only then remove it in a later version of Jellyfish.
+This makes the older versions of the SDKs still compatible with 
+newer Jellyfish until they are upgraded as well.
 
-This scenario proposes introducing breaking changes gradually,
-first by making the old features deprecated, and removing them
-later, giving users some time to adapt to the changes.
+## Testing
 
-This allows for the progressive introduction of new versions of Jellyfish,
-e.g. first by updating the Jellyfish Server and then the SDK.
-This also allows for working with two system versions at the same time
-(SDK connecting to different Jellyfish versions),
-until everything is upgraded.
+In order to assure quality, all the versions declared compatible
+will be tested against each other.
 
-### Example
-Let's say that we introduce backward-compatible changes between Jellyfish
-`0.2.0` versions and `0.4.0` versions. In the process, we marked
-some fields as deprecated and then remove them in Jellyfish `0.5.0`,
-while preserving compatibility with JF `0.3.0` and `0.4.0`.
-Similarly, in the version `0.6.0` we will likely break compatibility
-with `0.3.0` but remain compatible with `0.4.0` and `0.5.0`.
+At minimum, we should check that there are no breaking changes
+between API versions, or that the breaking changes are only
+related to resources previously marked deprecated.
 
-In this scenario, we need to decide how to version the API.
-The best way would be to keep it the same as Jellyfish,
-since most of the time any change in REST or WebSocket causes
-changes in Jellyfish.
+Tool such as [oasdiff](https://github.com/Tufin/oasdiff)
+will be of great help here.
+[Here](https://github.com/Tufin/oasdiff/blob/main/API-DEPRECATION.md)
+the oasdiff describes removal of deprecated resources.
 
-The downside is that a change in REST API triggers a version change
-in WebSocket API and vice versa. This is a disadvantage if someone uses 
-solely either REST API or WebSocket API - they would have to
-update the version even if there was no change in the API they were using.
+Simmilar tools are available for protobuf.
 
-We also have to test backward compatibility of the new changes we introduce.
-
-### Pros
-* backward-compatibility is provided to some point, e.g. up to two or three Jellyfish versions
-
-### Cons
-* more complicated testing - we have to test thoroughly each
-version combination we pledge viable
-* we need to provide the compatibility information to the users,
-semantic versioning isn't sufficient
-
-## Variations
-
-Instead of introducing breaking changes with every release, we could
-decide to implement them in bulk, e.g.
-
-JF `0.2.0` -> `0.6.0` - all backward compatible
-in JF `0.7.0` - introduce all changes previously marked as deprecated,
-making `0.7.0` incompatible even with `0.6.0`
+We should however introduce functional tests as well.


### PR DESCRIPTION
Proposal of the API versioning workflow. Once we settle on a way to version API, I will modify this document,
adding the technical details.

Read the doc here:
https://github.com/jellyfish-dev/jellyfish-docs/blob/api-versioning/docs/api_reference/versioning.md