### PR TITLE
Fix docker command

### DIFF
--- a/versioned_docs/version-0.2.0/getting_started/installation.md
+++ b/versioned_docs/version-0.2.0/getting_started/installation.md
@@ -94,7 +94,7 @@ need to set a couple of [environment variables](#environment-variables).
 An example docker command running bare Jellyfish HTTP service locally:
 
 ```bash
-docker run -p 8080:8080/tcp -e JF_HOST=localhost:8080 JF_SERVER_API_TOKEN=token ghcr.io/jellyfish-dev/jellyfish:0.2.0
+docker run -p 8080:8080/tcp -e JF_HOST=localhost:8080 -e JF_SERVER_API_TOKEN=token ghcr.io/jellyfish-dev/jellyfish:0.2.0
 ```
 
 Note that in real case scenarios, docker commands depend on peers/components you are going to use.

--- a/versioned_docs/version-0.2.1/getting_started/installation.md
+++ b/versioned_docs/version-0.2.1/getting_started/installation.md
@@ -94,7 +94,7 @@ need to set a couple of [environment variables](#environment-variables).
 An example docker command running bare Jellyfish HTTP service locally:
 
 ```bash
-docker run -p 8080:8080/tcp -e JF_HOST=localhost:8080 JF_SERVER_API_TOKEN=token ghcr.io/jellyfish-dev/jellyfish:0.2.0
+docker run -p 8080:8080/tcp -e JF_HOST=localhost:8080 -e JF_SERVER_API_TOKEN=token ghcr.io/jellyfish-dev/jellyfish:0.2.0
 ```
 
 Note that in real case scenarios, docker commands depend on peers/components you are going to use.


### PR DESCRIPTION
https://docs.docker.com/engine/reference/commandline/run/#env
Use the `-e, --env, and --env-file` flags to set simple **(non-array)** environment variables in the container you're running, or overwrite variables defined in the Dockerfile of the image you're running.

