### PR TITLE
Small HLS docs refactor

### DIFF
--- a/docs/getting_started/components/hls.md
+++ b/docs/getting_started/components/hls.md
@@ -19,10 +19,18 @@ See [API](../../for_developers/api_reference/rest_api#tag/room/operation/create_
 **Optional**
 
 * `lowLatency` (boolean, default: false) - whether the component should use LL-HLS
-* `persistent` (boolean, default: false) - whether the stream should be saved or not
+* `persistent` (boolean, default: false) - whether the stream should be saved or not.
+After a meeting that integrates an HLS component (with the persistent option set to true) ends, the meeting is preserved as a recording. 
+To manage this recording, use the [Recording API](../../for_developers/api_reference/rest_api#tag/recording).
+The recording is also available as [HLS Video On Demand (VOD) API](../../for_developers/api_reference/rest_api#tag/recording/operation/getRecordingContent).
 * `targetWindowDuration` (positive integer, default: null) - represents the duration, in seconds, of the live streaming content to be
     maintained in a rolling window. If set to null (default), the entire stream will be available.
-* `s3` (object, default: nil) - AWS S3 credentials. If credentials are set, the stream will be saved to the specified bucket.
+* `subscribeMode` (string "manual" or "auto", default: "auto") - whether HLS component should automatically start consuming available tracks.
+When set to `manual`, HLS component has to be explicitly told to subscribe for a specific peer/component tracks using 
+the [Subscription API](../../for_developers/api_reference/rest_api#tag/hls/operation/subscribe_tracks).
+* `s3` (object, default: null) - AWS S3 credentials. If credentials are set, the stream will be saved to the specified bucket.
+This solution will automatically send your streams to an AWS bucket right after the end of your meeting.
+For the exact credential structure see [Configuration API](../../for_developers/api_reference/rest_api#tag/room/operation/add_component).
 
 ## Env variables
 
@@ -32,23 +40,6 @@ Currently, there are no environment variables related to this component.
 
 After adding a WebRTC peer (and at least one track) or an RTSP component, the HLS stream will be available
 under `http://<jellyfish-address>/hls/<room_id>/index.m3u8` (or `https://`, if using TLS).
-
-## Recordings
-
-After a meeting that integrates an HLS component (with the persistent option set to true) ends, the meeting is preserved as a recording. 
-To manage this recording, use the [Recording API](../../for_developers/api_reference/rest_api#tag/recording).
-The recording is also available as HLS Video On Demand (VOD) [API](../../for_developers/api_reference/rest_api#tag/recording/operation/getRecordingContent).
-
-## Manual subscription
-
-If you do not want the HLS component to automatically subscribe to all available tracks, you can set the `subscribeMode` option to `manual`.
-In this mode, the HLS component will only subscribe to tracks that you explicitly instruct it to subscribe to using the subscription [API](http://localhost:3000/jellyfish-docs/next/for_developers/api_reference/rest_api#tag/hls/operation/subscribe_tracks).
-
-## Store HLS stream on S3
-
-You can directly store your HLS streams on S3. 
-This solution will automatically send your streams to an AWS bucket right after the end of your meetings.
-When initializing your stream, simply include your S3 credentials as part of the configuration [API](http://localhost:3000/jellyfish-docs/next/for_developers/api_reference/rest_api#tag/room/operation/add_component).
 
 ## Example Docker commands
 


### PR DESCRIPTION
So far we have had options and then sections that elaborate on those options.

My proposal is to merge everything into options so that we have e.g. s3 behavior described in one place.

Besides this, I also added `subscribeMode` option and explicitly stated where to find s3 credential structure.